### PR TITLE
Option for delayed CECActivateSource

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -81,6 +81,14 @@ msgctxt "#33117"
 msgid "CEC on Android (kernel)"
 msgstr "CEC on Android (kernel)"
 
+msgctxt "#33118"
+msgid "CEC timeout on wakeup (seconds)"
+msgstr "CEC timeout on wakeup (seconds)"
+
+msgctxt "#33119"
+msgid "CEC - Display notification on delayed wakeup"
+msgstr "CEC - Display notification on delayed wakeup"
+
 msgctxt "#33200"
 msgid "Power"
 msgstr "Power"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,6 +3,8 @@
   <category id="display" label="33100">
     <setting type="lsep" label="33101"/>
     <setting id="display_method" type="select" label="33102" help="33103" lvalues="33110|33111|33112|33113|33114|33115|33116|33117" default="1"/>
+    <setting id="cec_timeout" type="slider" label="33118" visible="eq(-1,1)" enable="true" default="0" range="0,1,15"option="int"/>
+    <setting id="cec_timeout_message" type="bool" label="33119" visible="eq(-2,1)" enable="!eq(-1,0)" default="false"/>
     <setting id="display_label" type="text" label="33103" enable="false" />
     <setting id="cec_label" type="text" label="33104" enable="false" />
     <setting id="rpi_label" type="text" label="33105" enable="false" />

--- a/screensaver.py
+++ b/screensaver.py
@@ -4,7 +4,7 @@ import subprocess
 import xbmc
 import xbmcaddon
 import xbmcgui
-
+import time
 
 def log_error(msg='', level=xbmc.LOGERROR):
     xbmc.log(msg='[%s] %s' % (addon_name, msg), level=level)
@@ -129,6 +129,10 @@ class Screensaver(xbmcgui.WindowXMLDialog):
         if display_method != 0:
             log_notice(msg='Turn display signal back on using method %s' % display_method)
         if display_method == '1':  # CEC (built-in)
+            cec_timeout_number = int(cec_timeout) 
+            if cec_timeout_message== 'true' and cec_timeout_number > 0: popup(msg="Cec activation delayed by %s s" % (cec_timeout_number),heading="Delayed activation")
+            time.sleep(cec_timeout_number)
+            if cec_timeout_message== 'true' and cec_timeout_number > 0: popup(msg="Cec activated",heading="Delayed activation")
             run_builtin('CECActivateSource')
         elif display_method == '2':  # No Signal on Raspberry Pi (using vcgencmd)
             run_command(['vcgencmd', 'display_power', '1'])
@@ -155,6 +159,8 @@ if __name__ == '__main__':
     addon_path = addon.getAddonInfo('path')
     addon_icon = addon.getAddonInfo('icon')
     display_method = addon.getSetting('display_method')
+    cec_timeout = addon.getSetting('cec_timeout')
+    cec_timeout_message = addon.getSetting('cec_timeout_message')
     power_method = addon.getSetting('power_method')
     logoff = addon.getSetting('logoff')
     mute = addon.getSetting('mute')


### PR DESCRIPTION
Added option to delay running CECActivateSource because remote control was not working on some TVs after wakeup.
Added slider to settings under CEC to select delay from 0 to 15 seconds
Added option to settings to show popup on delayed CECActivateSource