### PR TITLE
Add option to turn off screen on ODROID-C2

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -89,6 +89,10 @@ msgctxt "#33119"
 msgid "HDMI on Raspberry Pi (using tvservice)"
 msgstr ""
 
+msgctxt "#33120"
+msgid "Backlight on Odroid C2 (kernel)"
+msgstr ""
+
 msgctxt "#33200"
 msgid "Power"
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,7 +2,7 @@
 <settings>
   <category id="display" label="33100">
     <setting type="lsep" label="33101"/> <!-- display intro -->
-    <setting id="display_method" type="select" label="33102" help="33103" lvalues="33110|33111|33112|33113|33114|33115|33116|33117|33118|33119" default="1"/>
+    <setting id="display_method" type="select" label="33102" help="33103" lvalues="33110|33111|33112|33113|33114|33115|33116|33117|33118|33119|33120" default="1"/>
     <setting type="text" label="33103" enable="false"/> <!-- display_label -->
     <setting type="text" label="33104" enable="false"/> <!-- cec_label -->
     <setting type="text" label="33105" enable="false"/> <!-- rpi_label -->

--- a/screensaver.py
+++ b/screensaver.py
@@ -58,6 +58,10 @@ DISPLAY_METHODS = [
          function='run_command',
          args_off=['tvservice', '-o'],
          args_on=['tvservice', '-p']),
+    dict(name='backlight-odroid-c2', title='Backlight on Odroid C2 (kernel)',
+         function='run_command',
+         args_off=['su', '-c', 'echo 0 >/sys/class/amhdmitx/amhdmitx0/phy'],
+         args_on=['su', '-c', 'echo 1 >/sys/class/amhdmitx/amhdmitx0/phy']),
 ]
 
 POWER_METHODS = [

--- a/test/test_screensaver.py
+++ b/test/test_screensaver.py
@@ -36,7 +36,6 @@ class TestScreensaver(unittest.TestCase):
         time.sleep(5)
         turnoff.resume()
 
-    @unittest.expectedFailure
     def test_screensaver_command(self):
         ''' Test enabling screensaver '''
         screensaver.ADDON.settings['display_method'] = '2'


### PR DESCRIPTION
**From @ianmethyst in #9**
Added option to turn off the screen on [ODROID-C2](https://www.hardkernel.com/shop/odroid-c2/), which is an SBC similar to a Raspberry Pi. Unfortunately, none of the methods that worked on an RPi with my monitor could be used with this device. The method added works similarly as the one used in `backlight-rpi` method (i.e. using `echo 0 > ...` or `echo 1 > ...` on the corresponding file on sysfs). I replicated that one and changed the relevant parts.

Maybe there should be a text somewhere linking to this page: [How to turn off your monitor - ODROID-C2](https://wiki.odroid.com/odroid-c2/application_note/software/turn_off_monitor?s[]=turn&s[]=off), because there is a kernel parameter that should be enabled in the boot config file. I'm using LibreELEC and the parameter was enabled by default, but there may be other distros where this has to be done manually.

I have no experience in Kodi add-on development, so if I missed something, just tell me and I'll see what can I do to improve it.

I hope someone finds this useful.