### PR TITLE
Fix turning the screen on/off on some RPI systems

### DIFF
--- a/screensaver.py
+++ b/screensaver.py
@@ -4,10 +4,15 @@
 ''' This Kodi addon turns off display devices when Kodi goes into screensaver-mode '''
 
 from __future__ import absolute_import, division, unicode_literals
+import os
 import sys
 import atexit
 from xbmc import Monitor
 from xbmcgui import WindowXMLDialog
+
+# On some systems, commands might be in directories not on PATH env var, e.g. `vcgencmd` is under
+# /opt/vc/bin/ on OSMC. Add these paths to ensure the commands work on all systems.
+PATH = ':'.join((os.environ.get('PATH', ''),'/opt/vc/bin'))
 
 # NOTE: The below order relates to resources/settings.xml
 DISPLAY_METHODS = [
@@ -212,7 +217,7 @@ def run_command(*command, **kwargs):
     import subprocess
     # TODO: Add options for running using su or sudo
     try:
-        cmd = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False, **kwargs)
+        cmd = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False, env={"PATH": PATH}, **kwargs)
         (out, err) = cmd.communicate()
         if cmd.returncode == 0:
             log(2, "Running command '{command}' returned rc={rc}", command=' '.join(command), rc=cmd.returncode)


### PR DESCRIPTION
Hi, thanks for this plugin, it's essential in my OSMC RPI setup with a regular PC monitor which doesn't have a remote control.

The problem is, on some systems, vcgencmd is not on PATH. There doesn't seem to be a simple way to customize env vars passed to Kodi Python scripts but adding it to the PATH in screensaver.py works.

This should not break anything on other systems, just fix the problem on OSMC and other similar distributions.

Just a bit of context: my osmc user under which Kodi plugins/scripts are most likely run does have /opt/vc/bin on PATH but it's not present in os.environ["PATH"] when the scripts are run so even passing shell=True to Popen doesn't help. If someone knows how to set the PATH in this case, I'll gladly close the PR since it would be a cleaner solution.

Another fix of this problem was submitted in https://github.com/add-ons/screensaver.turnoff/pull/24 but I think it's a bit hardwired. Other distributions can have the command on different paths.